### PR TITLE
Add other selector supported by Autonumeric for directive

### DIFF
--- a/src/autonumeric/autonumeric.directive.ts
+++ b/src/autonumeric/autonumeric.directive.ts
@@ -25,8 +25,47 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import AutoNumeric from 'autonumeric';
 import { BasicInput } from './basic-input';
 
+
+/**
+ * Allowed Tag
+ *
+ *
+```
+'input', 'b', 'caption', 'cite', 'code', 'const', 'dd', 'del', 'div', 'dfn', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ins', 'kdb', 'label', 'li', 'option', 'output', 'p', 'q', 's', 'sample', 'span', 'strong', 'td', 'th', 'u'
+```
+ *
+ * ***
+ * @example
+ *
+```
+<input [ngAutonumeric]="{
+  digitGroupSeparator: ' ',
+  decimalCharacter: ',',
+  decimalCharacterAlternative: '.',
+  currencySymbol: '\u00a0€',
+  currencySymbolPlacement: 's',
+  roundingMethod: 'U',
+  minimumValue: '0'
+}" [(ngModel)]="myModel" (format)="onFormat($event)"(change)="onChange($event)" placeholder=''/>
+```
+ * Complete Example: https://stackblitz.com/edit/ng-autonumeric
+ *
+ * ***
+ *
+ * To generate selector
+ *
+ *
+```
+const allowedTagList = [
+  'input', 'b', 'caption', 'cite', 'code', 'const', 'dd', 'del', 'div', 'dfn', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ins', 'kdb', 'label', 'li', 'option', 'output', 'p', 'q', 's', 'sample', 'span', 'strong', 'td', 'th', 'u'
+]
+let selector = allowedTagList.join('[ngAutonumeric], ') + '[ngAutonumeric]';
+console.log(selector);
+```
+ *
+*/
 @Directive({
-    selector: 'input[ngAutonumeric]',
+    selector: 'input[ngAutonumeric], b[ngAutonumeric], caption[ngAutonumeric], cite[ngAutonumeric], code[ngAutonumeric], const[ngAutonumeric], dd[ngAutonumeric], del[ngAutonumeric], div[ngAutonumeric], dfn[ngAutonumeric], dt[ngAutonumeric], em[ngAutonumeric], h1[ngAutonumeric], h2[ngAutonumeric], h3[ngAutonumeric], h4[ngAutonumeric], h5[ngAutonumeric], h6[ngAutonumeric], ins[ngAutonumeric], kdb[ngAutonumeric], label[ngAutonumeric], li[ngAutonumeric], option[ngAutonumeric], output[ngAutonumeric], p[ngAutonumeric], q[ngAutonumeric], s[ngAutonumeric], sample[ngAutonumeric], span[ngAutonumeric], strong[ngAutonumeric], td[ngAutonumeric], th[ngAutonumeric], u[ngAutonumeric]',
     exportAs: 'ngAutonumeric',
     providers: [{
         provide: NG_VALUE_ACCESSOR,


### PR DESCRIPTION
According to https://github.com/autoNumeric/autoNumeric#on-other-dom-elements
Autonumeric does support other dom element

```javascript
const allowedTagList = [
    'b', 'caption', 'cite', 'code', 'const', 'dd', 'del', 'div', 'dfn', 'dt', 'em', 'h1', 'h2', 'h3',
    'h4', 'h5', 'h6', 'ins', 'kdb', 'label', 'li', 'option', 'output', 'p', 'q', 's', 'sample',
    'span', 'strong', 'td', 'th', 'u'
]
```

So I add all element that supported to `Directive` decorator

```javascript
@Directive({
    selector: 'input[ngAutonumeric], b[ngAutonumeric], caption[ngAutonumeric], cite[ngAutonumeric], code[ngAutonumeric], const[ngAutonumeric], dd[ngAutonumeric], del[ngAutonumeric], div[ngAutonumeric], dfn[ngAutonumeric], dt[ngAutonumeric], em[ngAutonumeric], h1[ngAutonumeric], h2[ngAutonumeric], h3[ngAutonumeric], h4[ngAutonumeric], h5[ngAutonumeric], h6[ngAutonumeric], ins[ngAutonumeric], kdb[ngAutonumeric], label[ngAutonumeric], li[ngAutonumeric], option[ngAutonumeric], output[ngAutonumeric], p[ngAutonumeric], q[ngAutonumeric], s[ngAutonumeric], sample[ngAutonumeric], span[ngAutonumeric], strong[ngAutonumeric], td[ngAutonumeric], th[ngAutonumeric], u[ngAutonumeric]',
    exportAs: 'ngAutonumeric',
    providers: [{
        provide: NG_VALUE_ACCESSOR,
        useExisting: forwardRef(() => NgAutonumericDirective),
        multi: true
    }],
})
```
***
Make selector from this code generator
_(I'm sorry, I don't know how to make dynamic selector)_
```javascript
const allowedTagList = [
  'input', 'b', 'caption', 'cite', 'code', 'const', 'dd', 'del', 'div', 'dfn', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ins', 'kdb', 'label', 'li', 'option', 'output', 'p', 'q', 's', 'sample', 'span', 'strong', 'td', 'th', 'u'
]
let selector = allowedTagList.join('[ngAutonumeric], ') + '[ngAutonumeric]';
console.log(selector);
```